### PR TITLE
chore: convert duration to ms

### DIFF
--- a/zapgorm.go
+++ b/zapgorm.go
@@ -24,7 +24,7 @@ func (l Logger) Print(values ...interface{}) {
 		l.zap.Debug("gorm.debug.sql",
 			zap.String("query", values[3].(string)),
 			zap.Any("values", values[4]),
-			zap.Duration("duration", values[2].(time.Duration)),
+			zap.Float64("duration in ms", float64(values[2].(time.Duration))/float64(time.Millisecond)),
 			zap.Int64("affected-rows", values[5].(int64)),
 			zap.String("source", values[1].(string)), // if AddCallerSkip(6) is well defined, we can safely remove this field
 		)


### PR DESCRIPTION
Hi! What do you think about this small change?

I recently got myself a couple of times converting nanosecs to milisecs when I wanted to measure the necessary time for my sql queries and I thought it might be the part of the original package as well.